### PR TITLE
Make `environment` optional within options

### DIFF
--- a/src/Brex.ts
+++ b/src/Brex.ts
@@ -37,10 +37,10 @@ export class Brex {
     ) {
         this.token = token;
         this.baseURL = 'https://platform.brexapis.com';
-        if(options?.baseURL){
+        if (options?.baseURL) {
             this.baseURL = options.baseURL;
-        } else if(options) {
-            this.baseURL = !/(prod|production)/.test(options.environment) ? "https://platform.staging.brexapps.com" : this.baseURL;
+        } else if (options?.environment) {
+            this.baseURL = options.environment === 'staging' ? 'https://platform.staging.brexapps.com' : this.baseURL;
         }
         this.apiVersion = options?.apiVersion || 'v1';
     }

--- a/src/types/ApiOptions.ts
+++ b/src/types/ApiOptions.ts
@@ -15,5 +15,5 @@ export interface ApiOptions {
     /**
      * The Brex environment to target. The options are "production" and "staging"
      */
-    environment: string;
+    environment?: 'production' | 'staging';
 }


### PR DESCRIPTION
With staging support, `environment` became required whenever any other options were provided. This PR makes it optional so that users can provide other API options without needing to explicitly provide an environment (defaulting to production).

Also adds clearer typing to the `environment` option, since only two valid options exist (`'production'` or `'staging'`).