### PR TITLE
docs: sync documentation with code changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Then add a changeset describing the user-facing change:
 bunx changeset
 ```
 
-Releases are automated: merged changesets accumulate into a release PR ([Changesets](https://github.com/changesets/changesets)); merging that publishes to npm with provenance. The `v2` branch is in `alpha` pre-mode (`2.0.0-alpha.N`) until `bunx changeset pre exit`.
+Releases are automated: merged changesets accumulate into a release PR ([Changesets](https://github.com/changesets/changesets)); merging that publishes to npm with provenance.
 
 ## Live smoke testing (optional)
 


### PR DESCRIPTION
🤖 **Docs audit** updated documentation to match the code change in `c4619e7de676`.

**What changed and why**

No other version/prerelease references in README.

- `CONTRIBUTING.md` — removed the stale claim that the `v2` branch is in `alpha` pre-mode (`2.0.0-alpha.N`), since this change exited Changesets prerelease mode and shipped stable `2.0.0`.

No other in-scope docs asserted the package version or alpha state. The README npm badge is dynamic (shields.io), and `CHANGELOG.md` is out of scope.

**Files updated**

- `CONTRIBUTING.md`

**What changed in the docs**

<details><summary>Show doc diff</summary>

```diff
diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
index 72b9add..a1d4a84 100644
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Then add a changeset describing the user-facing change:
 bunx changeset
 ```
 
-Releases are automated: merged changesets accumulate into a release PR ([Changesets](https://github.com/changesets/changesets)); merging that publishes to npm with provenance. The `v2` branch is in `alpha` pre-mode (`2.0.0-alpha.N`) until `bunx changeset pre exit`.
+Releases are automated: merged changesets accumulate into a release PR ([Changesets](https://github.com/changesets/changesets)); merging that publishes to npm with provenance.
 
 ## Live smoke testing (optional)
 
```

</details>

<sub>Generated by [docs-sentinel](https://github.com/slingshot/docs-sentinel). Review these doc edits before merging.</sub>
